### PR TITLE
Add a delay for receiving repeated messages before transmitting.

### DIFF
--- a/NRF24L01-Bi-Directional-Communication.ino
+++ b/NRF24L01-Bi-Directional-Communication.ino
@@ -270,6 +270,18 @@ void loop(void)
       displayPak.green = (float)green;
       displayPak.blue = (float)blue;
 
+      // Keep listening in case of transmitter is retransmitting the message
+      // The delay should be enough to cover all the possible retries
+      unsigned long wait_for_ready_start = millis();
+      while ((millis() - wait_for_ready_start) < 100)
+      {
+        if (radio.available())
+        {
+          controlDef dataDummy;
+          // Get (and discard) the answer data
+          radio.read(&dataDummy, sizeof(dataDummy));
+        }
+      }
 
       // Send the final one back. This way, we don't delay
       // the reply while we wait on serial i/o.


### PR DESCRIPTION
Solves https://github.com/SensorsIot/NRF24L01-Bi-Directional-Communication/issues/1 by adding a delay before switching roles and transmitting a response. 

Btw. I like your videos on youtube, thanks for all the useful information.

Edit: Maybe the same delay should be inserted for the potentiometer role after this line:
https://github.com/SensorsIot/NRF24L01-Bi-Directional-Communication/blob/6d7c91ea2b53dda640dd6912c7d68c7a62c5a4fb/NRF24L01-Bi-Directional-Communication.ino#L229
I am not sure and unable to test it now, unfortunately.